### PR TITLE
New Feature: Modifiable Tiles

### DIFF
--- a/start-page/cookies.html
+++ b/start-page/cookies.html
@@ -10,6 +10,7 @@
 		<link rel="stylesheet" href="style-page.css" type="text/css">
 	</head>
 	<body>
+		<div class="app">
 		<h2>Cookies Usage</h2>
 		For the Feren OS Start Page to work properly, this website uses cookies to store the following information offline:
 		<div class="extraspacing"><div class="bulletpoints"><p></p><p>• The search engine you last picked (lastengine) - This is used to remember your last picked Search Engine and choose it whenever the page loads, automatically.</p>
@@ -20,11 +21,11 @@
 		</div>
         	<p></p><h3>More Information:</h3>
         	<div class="extraspacing">You can get more information about cookies from the website linked to on the bottom button on the left of the one on the bottom-right, or by visiting <a href="https://cookiesandyou.com/" target="_blank">https://cookiesandyou.com/</a>, as well as information on how to block cookies in your browser.<p><i>Please note that if you block cookies on the Feren OS Start Page then the Settings items and Search Engine Remembering will no longer work.</i></p></div>
-        	</div><p>
+					</div>
 	</body>
 	<footer>
         <div class="footer" align="right">
-            <button class="btn-alt" type="submit" onclick=" window.open('https://cookiesandyou.com/','_blank')">What are Cookies?</button>
+						<button class="btn-alt" type="submit" onclick=" window.open('https://cookiesandyou.com/','_blank')">What are Cookies?</button>
         </div>
     </footer>
 

--- a/start-page/index.html
+++ b/start-page/index.html
@@ -12,7 +12,9 @@
 		<script src="scripts/jquery-1.4.2.min.js" type="text/javascript">
 		</script> <script src="scripts/tools.js" type="text/javascript"></script>
 		<script src="scripts/scripts.js" type="text/javascript">
-            setSettings();
+						setSettings();
+		</script>
+		<script src="scripts/tiles.js" type="text/javascript">
 		</script>
 		<script src="engines/base.js" type="text/javascript">
 		</script> <script type="text/javascript" src="scripts/jquery.js"></script>
@@ -38,14 +40,14 @@
 		    "message": "This website uses cookies to save your Start Page Settings offline.",
 		    "dismiss": "OK",
 		    "link": "More info",
-		    "href": "https://feren-os.github.io/start-page/cookies"
+		    "href": "cookies.html"
 		  }
 		})});
 		</script>
 	</head>
 	<body class="parallax" id="bgparallax" onload="setSettings()">
         <div class="toprighticon" align="right"><a href="https://feren-os-user-guide.readthedocs.io/"><img src="logo/User Guide.png" alt="Go to Feren OS User Guide"></a>
-        <a href="https://feren-os.github.io/start-page/settings.html"><img src="resources/settings.png" alt="Start Page Settings" title="Start Page Settings"/></a>
+        <a href="settings.html"><img src="resources/settings.png" alt="Start Page Settings" title="Start Page Settings"/></a>
         </div>	<div id="engines">
 		</div>
 		<div id="containersearch">
@@ -60,48 +62,48 @@
 			<p id="method"></p>
 		</div>
 		<div class="searchlabelspace"/>
-        <div class="shortcutscontainer">
-          <div class="grid-item" id="cell1"><span class="grid-item-contents">
-            <a href="https://ferenos.weebly.com">
-		        <img class="sd-item" src="resources/sd_feren-os.png" alt="Go to Feren OS Website" border="0">
-		    </a>
-          </span></div>
-          <div class="grid-item" id="cell1"><span class="grid-item-contents">
-            <a href="https://vivaldi.net/">
-		        <img class="sd-item" src="resources/sd_vivaldi_community.gif" alt="Go to Vivaldi Browser's Community" border="0">
-		    </a>
-          </span></div>
-          <div class="grid-item" id="cell1"><span class="grid-item-contents">
-            <a href="https://ferenos.weebly.com/discord">
-		        <img class="sd-item" src="resources/sd_discord.png" alt="Join the Feren OS Discord" border="0">
-		    </a>
-          </span></div>
-          <div class="grid-item" id="cell1"><span class="grid-item-contents">
-            <a href="https://twitter.com/Feren_OS">
-		        <img class="sd-item" src="resources/sd_feren_twitter.png" alt="Go to the Feren OS Google+ Community" border="0">
-		    </a>
-          </span></div>
-          <div class="grid-item" id="cell1"><span class="grid-item-contents">
-            <a href="https://omgubuntu.co.uk/">
-		        <img class="sd-item" src="resources/sd_omgubuntu.png" alt="Go to OMG! Ubuntu for news about Feren OS's base, and cool tips and tricks that (most of the time) work with Feren OS." border="0">
-		    </a>
-          </span></div>
-          <div class="grid-item" id="cell1"><span class="grid-item-contents">
-            <a href="https://facebook.com/">
-		        <img class="sd-item" src="resources/sd_facebook.png" alt="Go to Facebook" border="0">
-		    </a>
-          </span></div>
-          <div class="grid-item" id="cell1"><span class="grid-item-contents">
-            <a href="https://twitter.com/">
-		        <img class="sd-item" src="resources/sd_twitter.png" alt="Go to Twitter" border="0">
-		    </a>
-          </span></div>
-          <div class="grid-item" id="cell1"><span class="grid-item-contents">
-            <a href="https://chrome.google.com/webstore">
-		        <img class="sd-item" src="resources/sd_chrome_extensions.png" alt="Go to Vivaldi's StartMe Page" border="0">
-		    </a>
-          </span></div>
-        </div>
+		<div class="shortcutscontainer">
+			<div class="grid-item" id="cell1"><span class="grid-item-contents">
+				<a href="https://ferenos.weebly.com" id="cell1link">
+				<img class="sd-item" src="resources/sd_feren-os.png" alt="Go to Feren OS Website" border="0" id="cell1image">
+		</a>
+			</span></div>
+			<div class="grid-item" id="cell2"><span class="grid-item-contents">
+				<a href="https://vivaldi.net/" id="cell2link">
+				<img class="sd-item" src="resources/sd_vivaldi_community.gif" alt="Go to Vivaldi Browser's Community" border="0" id="cell2image">
+		</a>
+			</span></div>
+			<div class="grid-item" id="cell3"><span class="grid-item-contents">
+				<a href="https://ferenos.weebly.com/discord" id="cell3link">
+				<img class="sd-item" src="resources/sd_discord.png" alt="Join the Feren OS Discord" border="0" id="cell3image">
+		</a>
+			</span></div>
+			<div class="grid-item" id="cell4"><span class="grid-item-contents">
+				<a href="https://twitter.com/Feren_OS" id="cell4link">
+				<img class="sd-item" src="resources/sd_feren_twitter.png" alt="Go to the Feren OS Twitter Community" border="0" id="cell4image">
+		</a>
+			</span></div>
+			<div class="grid-item" id="cell5"><span class="grid-item-contents">
+				<a href="https://omgubuntu.co.uk/" id="cell5link">
+				<img class="sd-item" src="resources/sd_omgubuntu.png" alt="Go to OMG! Ubuntu for news about Feren OS's base, and cool tips and tricks that (most of the time) work with Feren OS." border="0" id="cell5image">
+		</a>
+			</span></div>
+			<div class="grid-item" id="cell6"><span class="grid-item-contents">
+				<a href="https://facebook.com/" id="cell6link">
+				<img class="sd-item" src="resources/sd_facebook.png" alt="Go to Facebook" border="0" id="cell6image">
+		</a>
+			</span></div>
+			<div class="grid-item" id="cell7"><span class="grid-item-contents">
+				<a href="https://twitter.com/ " id="cell7link">
+				<img class="sd-item" src="resources/sd_twitter.png" alt="Go to Twitter" border="0" id="cell7image">
+		</a>
+			</span></div>
+			<div class="grid-item" id="cell8"><span class="grid-item-contents">
+				<a href="https://chrome.google.com/webstore" id="cell8link">
+				<img class="sd-item" src="resources/sd_chrome_extensions.png" alt="Go to Vivaldi's StartMe Page" border="0" id="cell8image">
+		</a>
+			</span></div>
+		</div>
         <div class="blog-item"><div class="social-all">
         <div class="social-left"><!-- start feedwind code --> <script type="text/javascript" src="https://feed.mikle.com/js/fw-loader.js" data-fw-param="88913/" style="width: 90%;"></script> <!-- end feedwind code --></div>
         <div class="social-right"><a class="twitter-timeline" data-height="356" data-dnt="true" data-link-color="#006aff" href="https://twitter.com/Feren_OS?ref_src=twsrc%5Etfw">Tweets by Feren_OS</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script></div>
@@ -112,7 +114,11 @@
 		    <p>• The Feren OS Dev for the major edit of this Start Page (the one you're seeing right now)</p>
 		    <p>• Unsplash for the default background image</p>
 		    <p>• Vivaldi for the Start Page Tile Images</p>
-		    <p>• <a href="https://github.com/feren-OS/feren-os.github.io/pulls?utf8=✓&q=is%3Apr+is%3Amerged">Everyone who has contributed improvements to this Start Page</a></p></div>
+				<p>• <a href="https://github.com/feren-OS/feren-os.github.io/pulls?utf8=✓&q=is%3Apr+is%3Amerged">Everyone who has contributed improvements to this Start Page</a></p></div>
+				<script>
+			
+					initTiles();
+			 </script>
 	</body>
 
 <!-- Mirrored from www.logonoff.co/projects/startpage/ by HTTrack Website Copier/3.x [XR&CO'2014], Sun, 02 Jul 2017 11:38:26 GMT -->

--- a/start-page/scripts/scripts.js
+++ b/start-page/scripts/scripts.js
@@ -104,7 +104,10 @@ function setSettings()
     }
     if (hidecredits == "true") {
         $('.disclaimers').hide();
-    }
+		}
+		
+		
+		
 }
 
 

--- a/start-page/scripts/settings.js
+++ b/start-page/scripts/settings.js
@@ -38,4 +38,60 @@ function savesettings() {
     window.location.href = "https://feren-os.github.io/start-page";
 }
 
+// Make sure all tiles are set
+var i; 
+for (i=1; i < 9; i++) {
+    if (getCookie('tile' + i + 'settings') == 'undefined') {
+        setDefaultTileURLS()
+    }
+}
 
+var tileDefaultURLS = [
+    "",
+    "https://ferenos.weebly.com",
+    "https://vivaldi.net/",
+    "https://ferenos.weebly.com/discord",
+    "https://twitter.com/Feren_OS",
+    "https://omgubuntu.co.uk/",
+    "https://facebook.com/",
+    "https://twitter.com/",
+    "https://chrome.google.com/webstore"
+]
+
+function resetTileSettings() {
+    var tile = document.getElementById('tileNum').innerHTML;
+    setCookie("tile" + tile + "settings", tileDefaultURLS[tile]);
+    document.getElementById('tilewebsitetextbox').value=getCookie("tile" + tile + "settings")
+}
+
+function setDefaultTileURLS() {
+    setCookie("tile1settings",  tileDefaultURLS[1])
+    setCookie("tile2settings",  tileDefaultURLS[2])
+    setCookie("tile3settings",  tileDefaultURLS[3])
+    setCookie("tile4settings",  tileDefaultURLS[4])
+    setCookie("tile5settings",  tileDefaultURLS[5])
+    setCookie("tile6settings",  tileDefaultURLS[6])
+    setCookie("tile7settings",  tileDefaultURLS[7])
+    setCookie("tile8settings",  tileDefaultURLS[8])
+}
+
+function openTileSettings(tile) {
+    document.getElementById('tileNum').innerHTML = tile;
+    document.getElementById('tilewebsitetextbox').value=getCookie("tile" + tile + "settings");
+    document.getElementById('tilewebsitetextbox').placeholder=tileDefaultURLS[tile];
+    
+    if ( document.getElementById('tilewebsitetextbox').value == 'undefined' || document.getElementById('tilewebsitetextbox').value == '') {
+        setDefaultTileURLS();
+        document.getElementById('tilewebsitetextbox').value=getCookie("tile" + tile + "settings");
+    }
+    document.getElementById('tileSettings').style.display = 'inline-block';
+    document.getElementById('overlay').style.display = 'block';
+}
+
+function saveTileSettings() {
+    document.getElementById("tileSettings").style.display = 'none';
+    document.getElementById('overlay').style.display = 'none';
+    var tile = document.getElementById('tileNum').innerHTML;
+    setCookie("tile" + tile + "settings", document.getElementById("tilewebsitetextbox").value);
+    initTiles();
+}

--- a/start-page/scripts/tiles.js
+++ b/start-page/scripts/tiles.js
@@ -1,0 +1,49 @@
+function initTiles() {
+  var i; 
+    for (i=1; i < 9; i++) {
+				
+				var urlBg =  "http://placeholderimagegenerator.000webhostapp.com/440x360/000000/fff&text=" + getCookie('tile' + i + 'settings');
+				var urlAlt = "Go to " + getCookie('tile' + i + 'settings');
+				// Add custom logos for certain sites here
+			  if (getCookie('tile' + i + 'settings').indexOf('ferenos.weebly.com')  != -1) {
+					urlBg = "resources/sd_feren-os.png";
+					urlAlt = "Go to Feren OS Website";
+				}
+				if (getCookie('tile' + i + 'settings').indexOf('vivaldi.net')  != -1) {
+					urlBg = "resources/sd_vivaldi_community.gif";
+					urlAlt = "Go to Vivaldi Browser's Community";
+				}
+				if (getCookie('tile' + i + 'settings').indexOf('ferenos.weebly.com/discord')  != -1) {
+					urlBg = "resources/sd_discord.png";
+					urlAlt = "Join the Feren OS Discord";
+				}
+				if (getCookie('tile' + i + 'settings').indexOf('omgubuntu.co.uk') != -1) {
+					urlBg = "resources/sd_omgubuntu.png";
+					urlAlt = "Go to OMG! Ubuntu for news about Feren OS's base, and cool tips and tricks that (most of the time) work with Feren OS.";
+				}
+				if (getCookie('tile' + i + 'settings').indexOf('facebook.com')  != -1) {
+					urlBg = "resources/sd_facebook.png";
+					urlAlt = "Go to Facebook";
+				}
+				if (getCookie('tile' + i + 'settings').indexOf('twitter.com')  != -1) {
+					urlBg = "resources/sd_twitter.png";
+					urlAlt = "Go to Twitter";
+        }
+        // Make sure that top-level is in front of any subdomain
+        if (getCookie('tile' + i + 'settings').indexOf( 'twitter.com/Feren_OS')  != -1) {
+					urlBg = "resources/sd_feren_twitter.png";
+					urlAlt = "Go to the Feren OS Twitter Community";
+				}
+				if (getCookie('tile' + i + 'settings').indexOf('chrome.google.com/webstore')  != -1) {
+					urlBg = "resources/sd_chrome_extensions.png";
+					urlAlt = "Go to Vivaldi's Extensions Page";
+				}
+
+				document.getElementById('cell' + i + 'image').src = urlBg;
+        document.getElementById('cell' + i + 'image').alt = urlAlt;
+
+        if (Boolean(location.href.search('settings') == -1) == true) {
+          document.getElementById('cell' + i + 'link').href = getCookie('tile' + i + 'settings');
+        }
+		}
+}

--- a/start-page/settings.html
+++ b/start-page/settings.html
@@ -10,7 +10,7 @@
 		<title id="title">Feren OS Start Page Settings</title>
 		<link rel="stylesheet" href="style-page.css" type="text/css">
 		<script type="text/javascript" src="scripts/settings.js"></script>
-		
+		<script type="text/javascript" src="scripts/tiles.js"> </script>
 		<link rel="stylesheet" type="text/css" href="//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.1.0/cookieconsent.min.css" />
 		<script src="//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.1.0/cookieconsent.min.js"></script>
 		<script>
@@ -38,25 +38,75 @@
 		</script>
 	</head>
 	<body>
+		<div class="overlay" id="overlay"></div>
+		<div class="app">
 		<h2>Settings</h2>
 		<h3>Background Image:</h3>
 		Choose a background image for the Start Page, to be stored as a Cookie locally: <i>(only URLs are currently supported)</i>
-        </div><p>
+        <p>
         <input id="bgurltextbox" class="textbox" type="text" placeholder="../start-page/resources/bg.jpg"/></p>
         <script type="text/javascript">
             getbg();
         </script>
-        <h3>⠀</h3>
+				<h3>⠀</h3>
+				<h3>Modify Tiles</h3>
+				Select a tile to modify it's contents:
+				<div class="shortcutscontainer">
+          <div class="grid-item" id="cell1" onclick="openTileSettings(1)"><span class="grid-item-contents">
+		        <img class="sd-item" src="resources/sd_feren-os.png" alt="Go to Feren OS Website" border="0" id="cell1image">
+		    </a>
+          </span></div>
+          <div class="grid-item" id="cell2" onclick="openTileSettings(2)"><span class="grid-item-contents">
+		        <img class="sd-item" src="resources/sd_vivaldi_community.gif" alt="Go to Vivaldi Browser's Community" border="0" id="cell2image">
+		    </a>
+          </span></div>
+          <div class="grid-item" id="cell3" onclick="openTileSettings(3)"><span class="grid-item-contents">
+		        <img class="sd-item" src="resources/sd_discord.png" alt="Join the Feren OS Discord" border="0" id="cell3image">
+		    </a>
+          </span></div>
+          <div class="grid-item" id="cell4" onclick="openTileSettings(4)"><span class="grid-item-contents">
+		        <img class="sd-item" src="resources/sd_feren_twitter.png" alt="Go to the Feren OS Google+ Community" border="0" id="cell4image">
+		    </a>
+          </span></div>
+          <div class="grid-item" id="cell5" onclick="openTileSettings(5)"><span class="grid-item-contents">
+		        <img class="sd-item" src="resources/sd_omgubuntu.png" alt="Go to OMG! Ubuntu for news about Feren OS's base, and cool tips and tricks that (most of the time) work with Feren OS." border="0" id="cell5image">
+		    </a>
+          </span></div>
+          <div class="grid-item" id="cell6" onclick="openTileSettings(6)"><span class="grid-item-contents">
+		        <img class="sd-item" src="resources/sd_facebook.png" alt="Go to Facebook" border="0" id="cell6image">
+		    </a>
+          </span></div>
+          <div class="grid-item" id="cell7" onclick="openTileSettings(7)"><span class="grid-item-contents">
+		        <img class="sd-item" src="resources/sd_twitter.png" alt="Go to Twitter" border="0" id="cell7image">
+		    </a>
+          </span></div>
+          <div class="grid-item" id="cell8" onclick="openTileSettings(8)"><span class="grid-item-contents">
+		        <img class="sd-item" src="resources/sd_chrome_extensions.png" alt="Go to Vivaldi's StartMe Page" border="0" id="cell8image">
+		    </a>
+          </span></div>
+				</div>
         <h3>Hide elements of Start Page:</h3>
 		Choose what elements of the Start Page you'd like to have hidden:
-        </div><div class="extraspacing"><p>
+        <div class="extraspacing"><p>
         <input id="hidetilestoggle" type="checkbox"> All tiles</p>
         <input id="hideblogtoggle" type="checkbox"> Feren OS Blog and Twitter preview</p>
         <input id="hidecreditstoggle" type="checkbox"> Credits</p>
         <script type="text/javascript">
             gettickboxesstates();
         </script>
-        </div>
+				</div>
+				<div class="tileSettings" id="tileSettings">
+					<h4>Settings for Tile <span id="tileNum">1</span></h4>
+					Tile Website: <i>Make sure to add http:// or https:// in front of the URL</i>
+					<input id="tilewebsitetextbox" class="textbox" type="text" placeholder="https://feren-os.weebly.com"/></p>
+					<br>
+					<div style="text-align: center;"><button align="right" class="btn-blue" type="submit" onclick="resetTileSettings()">Reset to Default</button><button align="right" class="btn-blue" type="submit" onclick="saveTileSettings()">Save and Close</button></div>
+					
+				</div>
+			</div>
+			<script>
+				initTiles();
+			</script>
 	</body>
 	<footer>
         <div class="footer" align="right">

--- a/start-page/style-page.css
+++ b/start-page/style-page.css
@@ -3,7 +3,21 @@
 	padding: 0;
 	text-decoration: none;
 }
+.overlay {
+	margin: 0;
+	position: fixed;
+	width: 100%;
+	height: 100%;
+	background-color: rgba(0,0,0,0.5);
+	z-index: 5000000;
+	overflow-y: auto;
+	display: none;
+}
 
+.app {
+	margin-left: 20px;
+		margin-right: 20px;
+}
 @-webkit-keyframes slide {
 	0% {-webkit-transform: translateY(80px); opacity: 0;}
 	100% {-webkit-transform: translateY(0px); opacity: 1;}
@@ -56,12 +70,12 @@ body {
 	background-color: #ffffff;
 	font-family: 'Open Sans', sans-serif;
     color: black;
-    margin-left: 20px;
-    margin-right: 20px;
+	 overflow-y: auto;
 }
 
 body, html {
-    height: 100%;
+		height: 100%;
+		
 }
 
 .bulletpoints {
@@ -81,7 +95,7 @@ body, html {
 }
 
 h2 {
-    margin-top: 15px;
+    padding-top: 15px;
     font-size: 42px;
 	font-family: 'Lato Light', 'Open Sans Light', 'Segoe UI', 'Helvetica Neue', 'Roboto', sans-serif;
     color: black;
@@ -95,23 +109,36 @@ h3 {
 }
 
 .shortcutscontainer {
-	margin-top: 290px;
-    margin-left: 110px;
-    margin-right: 110px;
-    display: grid;
-    grid-template-columns: auto auto auto auto;
-    padding: 10px;
+	display: flex;
+margin-top: 0px;
+	margin-left: auto;
+	margin-right: auto;
+	flex-wrap: wrap;
+	/*flex-direction: row;*/
+	width: 84%;
+	padding: 10px;
 }
 
 .grid-item {
-  padding: 10px;
-  font-size: 30px;
-  text-align: center;
+display: flex;
+flex: 1px;
+padding-top: 10px;
+padding-bottom: 10px;
+font-size: 30px;
+text-align: center;
+}
+
+.grid-item-contents {
+	flex: 1;
 }
 
 .sd-item {
-  box-shadow: 0 0 rgba(0, 0, 0, 0.1), 0 0 3px 3px rgba(0, 0, 0, 0.07);
-  border: 1px solid rgba(0, 0, 0, 0.2);
+	float: center;
+	max-width: 240px;
+	padding: 0px;
+box-shadow: 0 0 rgba(0, 0, 0, 0.1), 0 0 2px 2px rgba(0, 0, 0, 0.05);
+border: 1px solid rgba(0, 0, 0, 0.2);
+cursor: pointer;
 }
 
 .btn {
@@ -120,7 +147,7 @@ h3 {
 
 input[type="text"] {
     width: 80%;
-    margin-top: 5px;
+    margin-top: 6px;
     font-size: 16px;
 	font-family: 'Open Sans', sans-serif;
 }
@@ -298,7 +325,8 @@ input[type="text"] {
   padding: .5em 2em;
   text-decoration: none;
   font-size: 16px;
-  font-family: 'Open Sans', sans-serif;
+	font-family: 'Open Sans', sans-serif;
+	cursor: pointer;
 }
 
 .btn-alt {
@@ -309,5 +337,30 @@ input[type="text"] {
   padding: .5em 2em;
   text-decoration: none;
   font-size: 16px;
-  font-family: 'Open Sans', sans-serif;
+	font-family: 'Open Sans', sans-serif;
+	cursor: pointer;
+}
+
+.grid-item-contents {
+	flex: 1;
+}
+
+/* 	TILE SETTINGS
+	----------------------------------------------------- */
+
+.tileSettings {
+    border: 1px solid black;
+    position: fixed;
+    width: 70vw;
+    max-width: 800px;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    padding: 20px;
+    background-color: ffffff;
+    z-index: 5000001;
+    max-height: calc(100% - 18px);
+    overflow-y: auto;
+		padding-left: 50px;
+		display: none;
 }


### PR DESCRIPTION
This PR contains code allowing for a user to modify the tiles shown on the Start Page. It has a way to show custom images for tiles, which are either created by my service, https://placeholderimagegenerator.000webhostapp.com or can be defined in the tiles.js file. 

It uses cookies to store the URLs. With this PR, the start page will create 8 new cookies to store website titles. You could add this to the cookie notice, as I did not.

Also, when generating the image from my service, if HTTP:// or HTTPS:// is added, the second slash is dropped, making HTTP:/example.com instead of HTTP://example.com. I can fix this if needed.

To change the background of images, please visit the service homepage, as it describes how to modify the image.