### PR TITLE
Add keyboard shortcut for previous engine

### DIFF
--- a/start-page/index.html
+++ b/start-page/index.html
@@ -61,7 +61,7 @@
     <div class="searchenginepopup" id="searchenginepopup">
         <h1>Choose a search engine</h1>
         <p style="line-height: 2px">⠀</p>
-        <p>Tip: You can press <kbd>CTRL</kbd> + <kbd>Left</kbd>/<kbd>Right</kbd> Arrow Key to quickly cycle between search engines.</p>
+        <p>Tip: You can press CTRL + Left or Right Arrow Keys to quickly cycle between search engines.</p>
         <p style="line-height: 10px">⠀</p>
         
         <div class="searchenginesscrollbox">

--- a/start-page/index.html
+++ b/start-page/index.html
@@ -61,7 +61,7 @@
     <div class="searchenginepopup" id="searchenginepopup">
         <h1>Choose a search engine</h1>
         <p style="line-height: 2px">⠀</p>
-        <p>Tip: You can press CTRL + Right Arrow Key to quickly cycle between search engines.</p>
+        <p>Tip: You can press <kbd>CTRL</kbd> + <kbd>Left</kbd>/<kbd>Right</kbd> Arrow Key to quickly cycle between search engines.</p>
         <p style="line-height: 10px">⠀</p>
         
         <div class="searchenginesscrollbox">

--- a/start-page/scripts/scripts.js
+++ b/start-page/scripts/scripts.js
@@ -197,7 +197,8 @@ $(document).keyup(function(e) {
 ).keydown(function(e) {
 	if (e.which == 17) isCtrl=true;
 	if (e.which == 91) isCmd=true;
-	
+
+    if (e.which == 37 && isCtrl == true)				{ /* Arrow Left */	prevEngine(); toggleChangeEnginePopup(false); }
 	if (e.which == 39 && isCtrl == true)				{ /* Arrow Right */	nextEngine(); toggleChangeEnginePopup(false); }
 });
 

--- a/start-page/scripts/tools.js
+++ b/start-page/scripts/tools.js
@@ -26,3 +26,19 @@ function findNext(where, now)
 	if (next == null) next = firstProp(where);
 	return next;
 }
+
+function findPrevious(where, now) 
+{
+	var previous = null;
+	for (item in where) {
+		if (item == now) {
+			break;
+		} else {
+			previous = item;	
+		};
+	}
+
+	// https://stackoverflow.com/a/21622274
+	if (previous == null) previous = Object.keys(where)[Object.keys(where).length-1];;
+	return previous;
+}


### PR DESCRIPTION
add `CTRL + <-` to cycle to previous search engine, update tip in search engine chooser